### PR TITLE
8-9-13: 武市さんFB追加対応（SQL説明・インデント注意・Seeder・Carbon）

### DIFF
--- a/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-3: 環境構築/13-3-1_development_environment.md
+++ b/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-3: 環境構築/13-3-1_development_environment.md
@@ -303,7 +303,9 @@ DB_PASSWORD=password
 
 ### 5-2. phpMyAdminの追加
 
-`compose.yaml`（または`docker-compose.yml`）を開き、`mysql`サービスの後に以下の設定を追加します。
+`compose.yaml`（または`docker-compose.yml`）を開き、`mysql`サービスの後に以下の設定を追加して保存します。
+
+> ⚠️ **注意**: YAMLファイルはインデント（字下げ）がずれると正しく動作しません。`phpmyadmin:`の左側のスペース数を、既にある`mysql:`と同じに揃えてください。
 
 ```yaml
     phpmyadmin:

--- a/curriculums/tutorial-8: データベースを使いこなそう📦/chapter-4: 高度なSQLクエリ/8-4-3_subqueries.md
+++ b/curriculums/tutorial-8: データベースを使いこなそう📦/chapter-4: 高度なSQLクエリ/8-4-3_subqueries.md
@@ -54,6 +54,8 @@ SQLの強力な機能を学んできましたが、それでも一度の単純�
 
 **例：`posts`テーブルの平均文字数より多い文字数の投稿を探す**
 
+> 💡 **補足**: `LENGTH()`は文字列の長さ（バイト数）を返すSQL関数です。`LENGTH(content)`で`content`カラムの文字数を取得できます。
+
 ```sql
 SELECT
     id, title, LENGTH(content) AS content_length
@@ -71,6 +73,8 @@ WHERE
 サブクエリが単一のカラム・複数の行（つまり、値のリスト）を返すパターンです。`IN`演算子と組み合わせることで、「サブクエリの結果リストに含まれる値」という条件を作成できます。
 
 **例：タグが1つも付いていない投稿を探す**
+
+> 💡 **補足**: `DISTINCT`は重複を除いて一意な値のみを取得するSQLキーワードです。`SELECT DISTINCT post_id`で、重複する`post_id`を除外した結果が得られます。
 
 ```sql
 SELECT * FROM posts

--- a/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-2_laravel_with_docker.md
+++ b/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-2_laravel_with_docker.md
@@ -175,6 +175,8 @@ DB_PASSWORD=password
 
 データベースをブラウザで管理できるように、phpMyAdminを追加する場合は、`docker-compose.yml`（または`compose.yaml`）を開き、`services:`の中にある`mysql`サービスの後に、以下の設定を追加して保存します。
 
+> ⚠️ **注意**: YAMLファイルはインデント（字下げ）がずれると正しく動作しません。`phpmyadmin:`の左側のスペース数を、既にある`mysql:`と同じに揃えてください。
+
 ```yaml
     phpmyadmin:
         image: 'phpmyadmin:latest'

--- a/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-7_environment_setup_hands_on.md
+++ b/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-7_environment_setup_hands_on.md
@@ -278,7 +278,9 @@ DB_PASSWORD=password
 **何を考えているか**：
 - 「データベースをブラウザで管理できるようにphpMyAdminを追加しよう」
 
-`compose.yaml`を開き、`mysql`サービスの後に以下の設定を追加します：
+`compose.yaml`を開き、`mysql`サービスの後に以下の設定を追加して保存します。
+
+> ⚠️ **注意**: YAMLファイルはインデント（字下げ）がずれると正しく動作しません。`phpmyadmin:`の左側のスペース数を、既にある`mysql:`と同じに揃えてください。
 
 ```yaml
     phpmyadmin:


### PR DESCRIPTION
## Summary
- 8-4-3: `LENGTH()`と`DISTINCT`の初出箇所に補足説明を追加
- 9-1-2, 9-1-7, 13-3-1: phpMyAdmin追加時のYAMLインデント注意と保存の記述を追加
- 9-3-9: ヒントセクションにSeederデータ例（5件分）を追加
- 9-4-9: `$casts`のCarbon説明に日付操作のメリットを補足

## 検証結果
- Issue #173: 全10項目中8件は問題なし、2件を修正
- Issue #176: 全6項目中5件は問題なし、1件を修正
- 詳細は各Issueコメント参照

Closes #173
Closes #176