### PR TITLE
3-1-6: ls -l 実行例から隠しファイル行を削除

### DIFF
--- a/curriculums/tutorial-3: エンジニアのPC操作方法を学ぼう💻/chapter-1: コマンドラインの理解と使い方/3-1-6_コマンドのオプションとヘルプ.md
+++ b/curriculums/tutorial-3: エンジニアのPC操作方法を学ぼう💻/chapter-1: コマンドラインの理解と使い方/3-1-6_コマンドのオプションとヘルプ.md
@@ -86,12 +86,13 @@ man ls
 
 ```bash
 ls -l
-# total 8
+# total 4
 # drwxr-xr-x 2 user group 4096 Dec 11 10:30 dir1
-# -rw-r--r-- 1 user group    0 Dec 11 10:45 .hidden-file.txt
 ```
 
 ファイル名だけでなく、パーミッション（権限）、所有者、サイズ、最終更新日時などが表示されます。
+
+なお、名前が `.` で始まる隠しファイル（ここでは `.hidden-file.txt`）は、`-l` だけでは表示されません。隠しファイルも一覧に含めたい場合は、次に紹介する `-a` オプションを使います。
 
 #### `ls -a`: 全て表示 (all)
 


### PR DESCRIPTION
## 概要

Slackお問い合わせ（件名: コマンド実行結果の確認 / 担当コーチ: 北岡功二様）対応。

Section 3-1-6 の `ls -l` 実行例に、`.hidden-file.txt`（`.` で始まる隠しファイル）が含まれていたが、`ls -l`（`-a` なし）は隠しファイルを表示しないため誤り。

## 修正内容

- `ls -l` 実行例から `.hidden-file.txt` の行を削除
- `total 8` → `total 4` に更新（dir1 のみを含む値に修正）
- 隠しファイルは `-a` 使用時に表示される旨の補足を1段落追加

## 関連

- Closes #220
- Slack permalink: https://estrahq.slack.com/archives/C08SY9BLPCP/p1776482404869169
