### PR TITLE
4: 4-4-2のリモートURLをSSHに統一

### DIFF
--- a/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-2_ローカルとリモートの接続.md
+++ b/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-2_ローカルとリモートの接続.md
@@ -13,7 +13,7 @@
 前のセクションで、あなたはGitHub上に、空のリモートリポジトリを作成しました。これで、あなたの手元には、2つのリポジトリが存在することになります。
 
 1.  **ローカルリポジトリ**: あなたのコンピュータ上にある、`my-first-git` ディレクトリ。
-2.  **リモートリポジトリ**: GitHubのサーバー上にある、`https://github.com/your-name/my-first-git.git` というURLのリポジトリ。
+2.  **リモートリポジトリ**: GitHubのサーバー上にある、`git@github.com:your-name/my-first-git.git` というURLのリポジトリ。
 
 しかし、現時点では、この2つのリポジトリは、お互いの存在を全く知りません。ただ、別々に存在しているだけです。
 
@@ -43,7 +43,11 @@ git remote add <ニックネーム> <リモートリポジトリのURL>
 
 それでは、実際にコマンドを実行します。ターミナルで、`my-first-git` ディレクトリの中にいることを確認してください。
 
-1.  **URLをコピーする**: 前のセクションで作成した、GitHubのリモートリポジトリのページを開きます。「Quick setup」のページで、HTTPSのURLをコピーします。通常は、`https://github.com/あなたのユーザー名/my-first-git.git` という形式です。
+1.  **URLをコピーする**: 前のセクションで作成した、GitHubのリモートリポジトリのページを開きます。「Quick setup」のページで、**SSHのタブに切り替えてから**、URLをコピーします。通常は、`git@github.com:あなたのユーザー名/my-first-git.git` という形式です。
+
+    > 💡 **HTTPSではなくSSHを使う理由**
+    >
+    > 前のチャプターの「4-2-3: GitHubのセットアップ」で、SSHキーをGitHubに登録しました。SSHのURLを使うことで、`push` や `pull` のたびにユーザー名やパスワードを聞かれることなく、安全にやり取りできます。「Quick setup」の画面では、デフォルトで「HTTPS」が選択されていることが多いので、忘れずに「SSH」のタブに切り替えてからURLをコピーしてください。
 
     <img alt="4-4-2_1.png" src="https://s3.ap-northeast-1.amazonaws.com/coachtech-lms-bucket-dev/curriculums/images/4-4-2_1.png">
 
@@ -51,7 +55,7 @@ git remote add <ニックネーム> <リモートリポジトリのURL>
 
     ```bash
     # URLの部分は、あなた自身のものに置き換えてください
-    git remote add origin https://github.com/your-name/my-first-git.git
+    git remote add origin git@github.com:your-name/my-first-git.git
     ```
 
     このコマンドは、成功しても、何もメッセージを返しません。しかし、水面下では、ローカルリポジトリの `.git/config` ファイルに、リモートリポジトリ `origin` の情報が、ひっそりと書き込まれています。
@@ -83,8 +87,8 @@ git remote -v
 以下のように、`origin` というニックネームに対して、2種類のURL（`fetch` と `push`）が登録されていれば、成功です。
 
 ```
-origin  https://github.com/your-name/my-first-git.git (fetch)
-origin  https://github.com/your-name/my-first-git.git (push)
+origin  git@github.com:your-name/my-first-git.git (fetch)
+origin  git@github.com:your-name/my-first-git.git (push)
 ```
 
 *   `fetch`: リモートからデータを取得（ダウンロード）するためのURL。
@@ -103,7 +107,7 @@ origin  https://github.com/your-name/my-first-git.git (push)
 *   **目的**: ローカルリポジトリに、変更を共有するための「共有の場所（リモートリポジトリ）」の住所を教える。
 *   **コマンド**: `git remote add <ニックネーム> <URL>`
 *   **ニックネーム**: 慣習として、中心的なリモートリポジトリには `origin` という名前を使う。
-*   **URL**: GitHubでリポジトリを作成した後に表示される、`.git` で終わるHTTPSのURL。
+*   **URL**: GitHubでリポジトリを作成した後に表示される、`.git` で終わるSSHのURL（`git@github.com:...` の形式）。
 *   **ブランチ名の変更**: `git branch -M main` で、ブランチ名をGitHubの標準である `main` に揃える。
 *   **確認**: `git remote -v` コマンドで、登録されたリモートリポジトリの情報を確認できる。
 

--- a/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-3_変更のアップロード.md
+++ b/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-3_変更のアップロード.md
@@ -59,7 +59,7 @@ Delta compression using up to 8 threads
 Compressing objects: 100% (4/4), done.
 Writing objects: 100% (6/6), 639 bytes | 639.00 KiB/s, done.
 Total 6 (delta 0), reused 0 (delta 0), pack-reused 0
-To https://github.com/your-name/my-first-git.git
+To github.com:your-name/my-first-git.git
  * [new branch]      main -> main
 ```
 

--- a/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-4_変更のダウンロード.md
+++ b/curriculums/tutorial-4: コードの管理方法を学ぼう👀/chapter-4: リモートのバージョン管理/4-4-4_変更のダウンロード.md
@@ -76,7 +76,7 @@ remote: Counting objects: 100% (5/5), done.
 remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 3 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), 296 bytes | 296.00 KiB/s, done.
-From https://github.com/your-name/my-first-git
+From github.com:your-name/my-first-git
    a1b2c3d..e4f5a6b  main       -> origin/main
 Updating a1b2c3d..e4f5a6b
 Fast-forward


### PR DESCRIPTION
## 概要

`4-2-3: GitHubのセットアップ` でSSH接続（`ssh-keygen` → 公開鍵登録 → `ssh -T git@github.com`）を完了させているにもかかわらず、`4-4-2: ローカルとリモートの接続 (git remote)` でHTTPSのURLを使うよう指示しており、学習者にとって不整合な指示になっていました。

SSHのURLを使うよう統一します。

## 変更内容

- `4-4-2_ローカルとリモートの接続.md`
  - 導入のリモートURL例を `git@github.com:...` 形式に変更
  - 「Quick setup」のコピー手順を「SSHのタブに切り替えてからコピー」に変更し、TIPでSSHを使う理由を補足
  - `git remote add origin` のコマンド例をSSH形式に変更
  - `git remote -v` の出力例をSSH形式に変更
  - まとめのURL説明をSSH形式に修正
- `4-4-3_変更のアップロード.md`
  - `git push` の出力例 `To ...` をSSH登録時の形式に変更
- `4-4-4_変更のダウンロード.md`
  - `git pull` の出力例 `From ...` をSSH登録時の形式に変更

> なお、ブラウザでアクセスするWeb URL（`https://github.com/your-name/my-first-git`）はHTTPSのままで正しいので、それらは変更していません。

## 元お問い合わせ
- Slack: https://coachtech.slack.com/archives/C08SY9BLPCP/p1777511910704209
- 担当コーチ: 野宗輝邦様

Closes #226

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkZ4mEApSmL8Xwqp7rq9WX)_