### PR TITLE
10-1-6: FortifyServiceProviderにアクションクラス登録とレート制限を追記

### DIFF
--- a/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-1: Laravelにおける認証/10-1-6_認証機能-ハンズオン演習.md
+++ b/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-1: Laravelにおける認証/10-1-6_認証機能-ハンズオン演習.md
@@ -780,8 +780,8 @@ mkdir -p resources/views/auth
 #### ステップ5: FortifyServiceProviderを設定する
 
 **何を考えているか**：
-- 「Fortifyに、どのビューを使うか教えよう」
-- 「loginViewとregisterViewを設定しよう」
+- 「Fortifyに、アクションクラス・レート制限・ビューを教えよう」
+- 「`10-1-2`で学んだ`boot`メソッドの内容を、ハンズオンでも反映しよう」
 
 `app/Providers/FortifyServiceProvider.php`を開いて、`boot`メソッドを以下のように編集します：
 
@@ -790,7 +790,15 @@ mkdir -p resources/views/auth
 
 namespace App\Providers;
 
+use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -802,6 +810,19 @@ class FortifyServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        // アクションクラスの登録
+        Fortify::createUsersUsing(CreateNewUser::class);
+        Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
+        Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
+        Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+
+        // ログイン試行回数の制限（1分間に5回まで）
+        RateLimiter::for('login', function (Request $request) {
+            $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());
+
+            return Limit::perMinute(5)->by($throttleKey);
+        });
+
         // ログインフォームのビューを指定
         Fortify::loginView(function () {
             return view('auth.login');
@@ -815,7 +836,24 @@ class FortifyServiceProvider extends ServiceProvider
 }
 ```
 
+> ⚠️ **アクションクラスの登録を忘れずに**
+>
+> 「アクションクラスの登録」を書き忘れると、ユーザー登録時に `Target [Laravel\Fortify\Contracts\CreatesNewUsers] is not instantiable.` というエラーが発生します。これは、Fortifyが「ユーザー登録時にどのアクションクラスを使えばよいか」を解決できないために起こります。
+
 **コードリーディング**：
+
+```php
+Fortify::createUsersUsing(CreateNewUser::class);
+```
+→ ユーザー登録時に`CreateNewUser`アクションを使うようFortifyに伝えます。これを書き忘れると、Fortifyは登録処理のクラスを解決できずエラーになります。
+
+```php
+RateLimiter::for('login', function (Request $request) {
+    // ...
+    return Limit::perMinute(5)->by($throttleKey);
+});
+```
+→ ログインを1分間に5回までに制限し、総当たり攻撃（ブルートフォース）への耐性を持たせます。
 
 ```php
 Fortify::loginView(function () {
@@ -1021,15 +1059,53 @@ return [
 ### app/Providers/FortifyServiceProvider.php
 
 ```php
-public function boot(): void
-{
-    Fortify::loginView(function () {
-        return view('auth.login');
-    });
+<?php
 
-    Fortify::registerView(function () {
-        return view('auth.register');
-    });
+namespace App\Providers;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+use Laravel\Fortify\Fortify;
+
+class FortifyServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        // アクションクラスの登録
+        Fortify::createUsersUsing(CreateNewUser::class);
+        Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
+        Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
+        Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+
+        // ログイン試行回数の制限（1分間に5回まで）
+        RateLimiter::for('login', function (Request $request) {
+            $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());
+
+            return Limit::perMinute(5)->by($throttleKey);
+        });
+
+        // ログインフォームのビューを指定
+        Fortify::loginView(function () {
+            return view('auth.login');
+        });
+
+        // ユーザー登録フォームのビューを指定
+        Fortify::registerView(function () {
+            return view('auth.register');
+        });
+    }
 }
 ```
 


### PR DESCRIPTION
## 概要

`10-1-6: 認証機能 - ハンズオン演習` を手順どおり進めると、ユーザー登録時に下記エラーが発生していました。

```
Target [Laravel\Fortify\Contracts\CreatesNewUsers] is not instantiable.
```

原因は `FortifyServiceProvider::boot()` で「アクションクラスの登録」が抜けていたためです。前セクションの `10-1-2: Fortifyの認証機能を理解する` には登場するコードが、ハンズオン側のステップ5と模範解答では欠落していました。

## 変更内容

- `curriculums/tutorial-10/.../10-1-6_認証機能-ハンズオン演習.md` の以下2箇所に、アクションクラス登録（`Fortify::createUsersUsing` 等）とレート制限（`RateLimiter::for('login', ...)`）の指定を追加：
  - **ステップ5: FortifyServiceProviderを設定する** — コード本体に追記し、注意書きとコードリーディングを補強
  - **模範解答 → app/Providers/FortifyServiceProvider.php** — `use` 文を含む完全なクラス定義に差し替え
- アクションクラス登録を忘れた場合のエラーメッセージを `⚠️` ブロックで明示し、原因と対処に気付きやすくしました

## 関連

- お問い合わせ: https://coachtech-jp.slack.com/archives/C08SY9BLPCP/p1779410497383109 （佐藤剣コーチからのご報告）

Closes #236

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMEHKhJxdn1ezX4QbVg6dr)_