### PR TITLE
9-1-2: Sail設定ファイル生成手順にcompose.yaml併記を追加

### DIFF
--- a/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-2_Docker環境でLaravelを動かそう.md
+++ b/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-2_Docker環境でLaravelを動かそう.md
@@ -126,7 +126,7 @@ docker run --rm \
 
 ### 3. Sailの設定ファイルをパブリッシュ
 
-次に、Sailの設定ファイル（`docker-compose.yml`）を生成します。MySQLを使用するように指定します。
+次に、Sailの設定ファイル（`docker-compose.yml`または`compose.yaml`）を生成します。MySQLを使用するように指定します。
 
 ```bash
 docker run --rm \
@@ -140,7 +140,7 @@ docker run --rm \
 
 このコマンドを実行すると、以下のファイルが生成されます。
 
-*   `docker-compose.yml`: Docker Composeの設定ファイル
+*   `docker-compose.yml`（または`compose.yaml`）: Docker Composeの設定ファイル
 *   `.env`ファイルの更新: データベース接続情報が自動設定される
 
 > 💡 **ポイント**: `--with=mysql`オプションで、MySQLを使用することを指定しています。他にも`pgsql`（PostgreSQL）、`redis`、`memcached`などを指定できます。


### PR DESCRIPTION
## 概要
9-1-2「3. Sailの設定ファイルをパブリッシュ」のファイル名表記を、セクション内の他箇所（「5. phpMyAdminの追加」「6. Sailの起動」）と揃えて `docker-compose.yml` / `compose.yaml` の併記に統一しました。

新しめのLaravel Sail / Docker Composeでは `compose.yaml` が生成される場合があり、本文では `docker-compose.yml` 単独表記だったため、生徒がつまずく原因になっていました。

## 変更内容
- 本文（生成されるファイルの案内）: 「Sailの設定ファイル（`docker-compose.yml`または`compose.yaml`）を生成します。」
- 生成ファイル一覧: 「`docker-compose.yml`（または`compose.yaml`）: Docker Composeの設定ファイル」

Closes #238

---
元お問い合わせ: https://estrahq.slack.com/archives/C08SY9BLPCP/p1779895725238309?thread_ts=1779895725.238309&cid=C08SY9BLPCP

---
_Generated by [Claude Code](https://claude.ai/code/session_012oemLymG4MJLVXH5rMLaeh)_