### PR TITLE
9-1-7/10-4-6/10-5-7/11-2-8: ハンズオンのGitHub push手順のパス・プロジェクト名を修正

### DIFF
--- a/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-4: デバッグの重要性/10-4-6_デバッグ-ハンズオン演習.md
+++ b/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-4: デバッグの重要性/10-4-6_デバッグ-ハンズオン演習.md
@@ -75,22 +75,22 @@ Chapter 4で学んだデバッグ手法を実際に手を動かして確認し�
 
 完成した成果物を **GitHubのpublicリポジトリ** で管理します。
 
-- `~/laravel-practice/10-4-6_hands-on/debug-app-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
-- リポジトリ名は **`debug-app-practice`** とする
+- `~/laravel-practice/10-4-6_hands-on/debugging-app-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
+- リポジトリ名は **`debugging-app-practice`** とする
 - 下記の雛形をもとに、`README.md` を **自分の言葉で** 作成する
 - コミットとpushを完了させる
 
 > 💡 **`practice/` と `sample/` の使い分け**:
-> - **`debug-app-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
-> - **`debug-app-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
+> - **`debugging-app-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
+> - **`debugging-app-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
 
 <details>
 <summary>📄 README.md の雛形（クリックで展開）</summary>
 
-`debug-app-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
+`debugging-app-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
 
 ````markdown
-# debug-app-practice
+# debugging-app-practice
 
 ## 概要
 COACHTECH 教材 Tutorial 10-4「デバッグ ハンズオン演習」で作成した成果物です。
@@ -812,8 +812,8 @@ Route::middleware('log.lifecycle')->group(function () {
 5-1-7 で覚えた手順を使って、成果物をGitHubの **publicリポジトリ** に push しましょう。
 
 ```bash
-# debug-app-practice ディレクトリに移動
-cd ~/laravel-practice/10-4-6_hands-on/debug-app-practice
+# debugging-app-practice ディレクトリに移動
+cd ~/laravel-practice/10-4-6_hands-on/debugging-app-practice
 
 # Git の初期化、commit、リモート設定、push
 git init
@@ -828,7 +828,7 @@ git push -u origin main
 
 ### ✅ push 完了チェック
 
-- [ ] GitHub に `debug-app-practice` リポジトリを作成した（**public** で作成）
+- [ ] GitHub に `debugging-app-practice` リポジトリを作成した（**public** で作成）
 - [ ] 「📦 GitHubでのコード管理」の雛形を参考に `README.md` を **自分の言葉で** 作成した
 - [ ] `commit` と `push` を完了して、GitHubに反映されている
 

--- a/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-5: テストの種類と扱い方/10-5-7_テスト-ハンズオン演習.md
+++ b/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-5: テストの種類と扱い方/10-5-7_テスト-ハンズオン演習.md
@@ -59,22 +59,22 @@ Laravelのテスト機能を使って、ユーザー作成機能のテストコ�
 
 完成した成果物を **GitHubのpublicリポジトリ** で管理します。
 
-- `~/laravel-practice/10-5-7_hands-on/test-app-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
-- リポジトリ名は **`test-app-practice`** とする
+- `~/laravel-practice/10-5-7_hands-on/testing-app-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
+- リポジトリ名は **`testing-app-practice`** とする
 - 下記の雛形をもとに、`README.md` を **自分の言葉で** 作成する
 - コミットとpushを完了させる
 
 > 💡 **`practice/` と `sample/` の使い分け**:
-> - **`test-app-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
-> - **`test-app-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
+> - **`testing-app-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
+> - **`testing-app-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
 
 <details>
 <summary>📄 README.md の雛形（クリックで展開）</summary>
 
-`test-app-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
+`testing-app-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
 
 ````markdown
-# test-app-practice
+# testing-app-practice
 
 ## 概要
 COACHTECH 教材 Tutorial 10-5「テスト ハンズオン演習」で作成した成果物です。
@@ -719,8 +719,8 @@ ls database/factories/
 5-1-7 で覚えた手順を使って、成果物をGitHubの **publicリポジトリ** に push しましょう。
 
 ```bash
-# test-app-practice ディレクトリに移動
-cd ~/laravel-practice/10-5-7_hands-on/test-app-practice
+# testing-app-practice ディレクトリに移動
+cd ~/laravel-practice/10-5-7_hands-on/testing-app-practice
 
 # Git の初期化、commit、リモート設定、push
 git init
@@ -735,7 +735,7 @@ git push -u origin main
 
 ### ✅ push 完了チェック
 
-- [ ] GitHub に `test-app-practice` リポジトリを作成した（**public** で作成）
+- [ ] GitHub に `testing-app-practice` リポジトリを作成した（**public** で作成）
 - [ ] 「📦 GitHubでのコード管理」の雛形を参考に `README.md` を **自分の言葉で** 作成した
 - [ ] `commit` と `push` を完了して、GitHubに反映されている
 

--- a/curriculums/tutorial-11: LaravelにおけるAPIの概念と使い方を学ぼう🛜/chapter-2: 様々なAPI処理/11-2-8_ハンズオン-タスク管理APIのCRUD実装.md
+++ b/curriculums/tutorial-11: LaravelにおけるAPIの概念と使い方を学ぼう🛜/chapter-2: 様々なAPI処理/11-2-8_ハンズオン-タスク管理APIのCRUD実装.md
@@ -77,22 +77,22 @@ Chapter 2で学んだCRUD操作を実際に手を動かして確認します。�
 
 完成した成果物を **GitHubのpublicリポジトリ** で管理します。
 
-- `~/api-practice/11-2-8_hands-on/task-api-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
-- リポジトリ名は **`task-api-practice`** とする
+- `~/api-practice/11-2-8_hands-on/task-crud-practice/` ディレクトリの中身（Laravelプロジェクト一式）を **publicリポジトリ** で管理する
+- リポジトリ名は **`task-crud-practice`** とする
 - 下記の雛形をもとに、`README.md` を **自分の言葉で** 作成する
 - コミットとpushを完了させる
 
 > 💡 **`practice/` と `sample/` の使い分け**:
-> - **`task-api-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
-> - **`task-api-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
+> - **`task-crud-practice/`** が **「提出物」** です。最終的にここにある成果物をGitHubに push します
+> - **`task-crud-sample/`** は **「答え合わせ用」** で、ローカルでの比較確認のみに使います。GitHubには push しません
 
 <details>
 <summary>📄 README.md の雛形（クリックで展開）</summary>
 
-`task-api-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
+`task-crud-practice/README.md` に、以下の雛形をベースに **自分の言葉で** 記載しましょう（Laravelデフォルトの README を置き換えてOK）。
 
 ````markdown
-# task-api-practice
+# task-crud-practice
 
 ## 概要
 COACHTECH 教材 Tutorial 11-2「タスク管理APIのCRUD実装」で作成した成果物です。
@@ -1043,8 +1043,8 @@ Route::apiResource('tasks', TaskController::class);
 5-1-7 で覚えた手順を使って、成果物をGitHubの **publicリポジトリ** に push しましょう。
 
 ```bash
-# task-api-practice ディレクトリに移動
-cd ~/api-practice/11-2-8_hands-on/task-api-practice
+# task-crud-practice ディレクトリに移動
+cd ~/api-practice/11-2-8_hands-on/task-crud-practice
 
 # Git の初期化、commit、リモート設定、push
 git init
@@ -1059,7 +1059,7 @@ git push -u origin main
 
 ### ✅ push 完了チェック
 
-- [ ] GitHub に `task-api-practice` リポジトリを作成した（**public** で作成）
+- [ ] GitHub に `task-crud-practice` リポジトリを作成した（**public** で作成）
 - [ ] 「📦 GitHubでのコード管理」の雛形を参考に `README.md` を **自分の言葉で** 作成した
 - [ ] `commit` と `push` を完了して、GitHubに反映されている
 

--- a/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-7_環境構築ハンズオン.md
+++ b/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-1: 環境構築と基礎概念/9-1-7_環境構築ハンズオン.md
@@ -539,7 +539,7 @@ phpMyAdminの画面が表示され、`laravel`データベースが確認でき�
 
 ```bash
 # setup-app-practice ディレクトリに移動
-cd ~/laravel-practice/setup-app-practice
+cd ~/laravel-practice/9-1-7_hands-on/setup-app-practice
 
 # Git の初期化、commit、リモート設定、push
 git init


### PR DESCRIPTION
## 概要

ハンズオンの「📤 GitHubに push しよう」セクションについて、push手順の `cd` 先が「実際に作成されるプロジェクトの場所・名前」と一致していない不整合を横断調査し、まとめて修正します。

## 修正内容

### 9-1-7（環境構築ハンズオン）

push手順の `cd` パスに中間ディレクトリ `9-1-7_hands-on/` が欠けていたため修正。

```diff
- cd ~/laravel-practice/setup-app-practice
+ cd ~/laravel-practice/9-1-7_hands-on/setup-app-practice
```

### 10-4-6 / 10-5-7 / 11-2-8（プロジェクト名の不一致）

実際に作成するプロジェクト名（`git clone` / `composer create-project` の引数）と、「📦 GitHubでのコード管理」「README雛形」「📤 push しよう」「push完了チェックリスト」で使われている名前がズレていたため、実際の作成名に統一しました。

| ファイル | 修正前 | 修正後 |
|:--|:--|:--|
| 10-4-6 | `debug-app-practice` / `-sample` | `debugging-app-practice` / `-sample` |
| 10-5-7 | `test-app-practice` / `-sample` | `testing-app-practice` / `-sample` |
| 11-2-8 | `task-api-practice` / `-sample` | `task-crud-practice` / `-sample` |

学習者は正しい名前でプロジェクトを作成するのに、push手順では存在しないディレクトリへ `cd` する形になり詰まる状態でした。

## 調査範囲

「📤 push しよう」を持つハンズオン全20ファイルを照合。上記4ファイル以外（5-1-7 / 7-1-6 / 7-2-6 / 7-3-4 / 7-4-3 / 9-1-8 / 9-2-5 / 9-3-9 / 9-4-9 / 9-5-5 / 9-6-5 / 10-1-6 / 10-2-4 / 10-3-5 / 10-6-6 / 11-1-7）は問題なしを確認済みです。

## 関連

- Slack: https://coachtech-cti.slack.com/archives/C08SY9BLPCP/p1780488078296769
- ご指摘者: 【コーチ】今井菜月様

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)