### PR TITLE
9-6-1: 日本語化パッケージを laravel-lang/common に変更

### DIFF
--- a/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-6: 入力の制約/9-6-1_バリデーションの基礎.md
+++ b/curriculums/tutorial-9: webフレームワークLaravelの基礎的な使い方を学ぼう🪛/chapter-6: 入力の制約/9-6-1_バリデーションの基礎.md
@@ -186,12 +186,14 @@ Laravelには、様々なバリデーションルールが用意されていま�
 
 #### ステップ1: 言語ファイルをインストールする
 
-Laravelの公式日本語化リポジトリから、言語ファイルをダウンロードします。
+Laravelの日本語化用パッケージ（`laravel-lang/common`）をインストールし、日本語の言語ファイルを追加します。
 
 ```bash
-docker compose exec php composer require laravel-lang/lang --dev
-sail artisan lang:publish ja
+sail composer require laravel-lang/common --dev
+sail artisan lang:add ja
 ```
+
+> 💡 **TIP**: 以前は `laravel-lang/lang` というパッケージが使われていましたが、現在は非推奨となっており、`composer install` 時にエラー（マルウェアとしてブロック）が発生します。代わりに `laravel-lang/common` を使用してください。
 
 #### ステップ2: デフォルトの言語を日本語に設定する
 


### PR DESCRIPTION
## 概要

Section 9-6-1「バリデーションの基礎」のエラーメッセージ日本語化手順を、現行の `laravel-lang/common` パッケージを使うように修正しました。

## 背景

教材で案内している `laravel-lang/lang` パッケージが Packagist 上で **マルウェアとしてフラグ** され、`composer install` 時にブロックされるようになり、教材通りに進めると環境構築が失敗する状態でした。

```
Package laravel-lang/lang 7.0.9 (in the lock file) was not loaded,
because it was flagged as malware
```

## 変更内容

- 「エラーメッセージの日本語化」のステップ1のコマンドを差し替え
  - `docker compose exec php composer require laravel-lang/lang --dev` → `sail composer require laravel-lang/common --dev`
  - `sail artisan lang:publish ja` → `sail artisan lang:add ja`
- 旧パッケージが利用できなくなった経緯を TIP で補足

## 関連

- Slack: #ct_service_contact / 2026-06-09 01:30 JST / 担当コーチ: 佐藤剣様
- Closes #246

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWzM5canodrSbXsvdPt3sd)_