### PR TITLE
10-5-7: sail:install に --php=8.2 を指定して PHP バージョンを固定

### DIFF
--- a/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-5: テストの種類と扱い方/10-5-7_テスト-ハンズオン演習.md
+++ b/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-5: テストの種類と扱い方/10-5-7_テスト-ハンズオン演習.md
@@ -196,7 +196,7 @@ docker run --rm \
     -w /var/www/html \
     -e COMPOSER_CACHE_DIR=/tmp/composer_cache \
     laravelsail/php82-composer:latest \
-    php artisan sail:install --with=mysql
+    php artisan sail:install --with=mysql --php=8.2
 ```
 
 <details>
@@ -357,7 +357,7 @@ docker run --rm \
     -w /var/www/html \
     -e COMPOSER_CACHE_DIR=/tmp/composer_cache \
     laravelsail/php82-composer:latest \
-    php artisan sail:install --with=mysql
+    php artisan sail:install --with=mysql --php=8.2
 ```
 
 <details>


### PR DESCRIPTION
## 概要

Section 10-5-7「テスト ハンズオン演習」の Sail インストール手順で、PHP バージョンを `8.2` に固定するようコマンドを修正しました。

## 背景

Laravel 10 がサポートする PHP は `8.1〜8.3` ですが、現状の手順では `sail:install` が選ぶ PHP バージョン（最新）にホスト環境次第で `8.5` が選ばれてしまい、deprecated 警告が表示されます。

特にテスト実行時、教材では:
```
Tests:    2 passed (3 assertions)
```
となるはずが、実際は:
```
Tests:    2 deprecated (3 assertions)
```
と表示され、教材どおりにならない問題がありました。

## 変更内容

- `practice`/`sample` 両プロジェクト用の `sail:install` コマンドに `--php=8.2` を追加（2箇所）
  - `php artisan sail:install --with=mysql` → `php artisan sail:install --with=mysql --php=8.2`

## 関連

- Slack: #ct_service_contact / 2026-06-09 01:17 JST / 担当コーチ: 佐藤剣様
- Closes #248

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWzM5canodrSbXsvdPt3sd)_