### PR TITLE
12,13: git remote add origin の URL を SSH 形式に修正

### DIFF
--- a/curriculums/tutorial-12: チーム開発で重要なgitとgithubの実践的な使い方を学ぼう💡/chapter-2: イシュー駆動開発/12-2-4_ハンズオン-GitHub連携演習.md
+++ b/curriculums/tutorial-12: チーム開発で重要なgitとgithubの実践的な使い方を学ぼう💡/chapter-2: イシュー駆動開発/12-2-4_ハンズオン-GitHub連携演習.md
@@ -160,7 +160,7 @@ git commit -m "Initial commit"
 
 ```bash
 # リモートリポジトリを追加（URLは自分のものに置き換え）
-git remote add origin https://github.com/あなたのユーザー名/github-collab-practice.git
+git remote add origin git@github.com:あなたのユーザー名/github-collab-practice.git
 
 # プッシュ
 git push -u origin main
@@ -239,7 +239,7 @@ git commit -m "Initial commit"
 
 ```bash
 # リモートリポジトリを追加（URLは自分のものに置き換え）
-git remote add origin https://github.com/あなたのユーザー名/github-collab-sample.git
+git remote add origin git@github.com:あなたのユーザー名/github-collab-sample.git
 
 # プッシュ
 git push -u origin main

--- a/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-3: 環境構築/13-3-3_Git・GitHub準備とIssue登録.md
+++ b/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-3: 環境構築/13-3-3_Git・GitHub準備とIssue登録.md
@@ -79,7 +79,7 @@ git commit -m "Initial commit"
 git branch -M main
 
 # リモートリポジトリを追加
-git remote add origin https://github.com/あなたのユーザー名/task-manager.git
+git remote add origin git@github.com:あなたのユーザー名/task-manager.git
 
 # プッシュ
 git push -u origin main


### PR DESCRIPTION
## 概要

tutorial-4「Git入門」（`4-4-2_ローカルとリモートの接続.md`）では、リモートリポジトリへの接続を SSH 形式（`git@github.com:...`）で説明しているにもかかわらず、tutorial-12 と tutorial-13 のハンズオンでは HTTPS 形式（`https://github.com/...`）で記載されており、教材内で不整合となっていました。

指摘どおり、3 箇所すべてを SSH 形式に統一します。

## 修正箇所

| ファイル | 行 | 変更前 → 変更後 |
|:---|:---|:---|
| `curriculums/tutorial-12: ...チーム開発.../12-2-4_ハンズオン-GitHub連携演習.md` | L163 | `https://github.com/あなたのユーザー名/github-collab-practice.git` → `git@github.com:あなたのユーザー名/github-collab-practice.git` |
| 同上 | L242 | `https://github.com/あなたのユーザー名/github-collab-sample.git` → `git@github.com:あなたのユーザー名/github-collab-sample.git` |
| `curriculums/tutorial-13: ...総仕上げ.../13-3-3_Git・GitHub準備とIssue登録.md` | L82 | `https://github.com/あなたのユーザー名/task-manager.git` → `git@github.com:あなたのユーザー名/task-manager.git` |

## 関連

- Slack permalink: https://estrahq.slack.com/archives/C08SY9BLPCP/p1782276411397749

Closes #254

---
_Generated by [Claude Code](https://claude.ai/code/session_014QDtHTxATD8wX17JUM8mhE)_