### PR TITLE
10, 13: FortifyのprovidersコードをLaravel 10形式に修正

### DIFF
--- a/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-1: Laravelにおける認証/10-1-2_Fortifyの認証機能を理解する.md
+++ b/curriculums/tutorial-10: webフレームワークLaravelの実践的に使いこなそう🛠️/chapter-1: Laravelにおける認証/10-1-2_Fortifyの認証機能を理解する.md
@@ -134,7 +134,7 @@ sail artisan route:list --path=logout
 **`config/app.php`**
 
 ```php
-'providers' => [
+'providers' => ServiceProvider::defaultProviders()->merge([
     // ...既存のプロバイダ
 
     /*
@@ -146,7 +146,7 @@ sail artisan route:list --path=logout
     App\Providers\EventServiceProvider::class,
     App\Providers\RouteServiceProvider::class,
     App\Providers\FortifyServiceProvider::class, // ← この行を追加
-],
+])->toArray(),
 ```
 
 > ⚠️ **注意**: この登録を忘れると、Fortifyのルートやビューが機能しません。

--- a/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-5: 認証機能/13-5-1_認証機能の実装.md
+++ b/curriculums/tutorial-13: 総仕上げ！学んだ技術をフル活用してアプリケーションを作ってみよう🔥/chapter-5: 認証機能/13-5-1_認証機能の実装.md
@@ -102,7 +102,7 @@ sail artisan vendor:publish --provider="Laravel\Fortify\FortifyServiceProvider"
 `config/app.php` の `providers` 配列にFortifyServiceProviderを追加します。
 
 ```php
-'providers' => [
+'providers' => ServiceProvider::defaultProviders()->merge([
     // ...既存のプロバイダ
 
     /*
@@ -114,7 +114,7 @@ sail artisan vendor:publish --provider="Laravel\Fortify\FortifyServiceProvider"
     App\Providers\EventServiceProvider::class,
     App\Providers\RouteServiceProvider::class,
     App\Providers\FortifyServiceProvider::class, // ← この行を追加
-],
+])->toArray(),
 ```
 
 #### コードリーディング
@@ -532,11 +532,11 @@ if (auth()->guest()) {
 
 ```php
 // ❌ NG: config/app.php の providers に追加し忘れ
-'providers' => [
+'providers' => ServiceProvider::defaultProviders()->merge([
     // ...
     App\Providers\AppServiceProvider::class,
     // FortifyServiceProviderがない
-],
+])->toArray(),
 ```
 
 **対処法**: `config/app.php` の `providers` 配列に `App\Providers\FortifyServiceProvider::class` を追加する。


### PR DESCRIPTION
## 概要

Closes #261

Slackお問い合わせ（[permalink](https://estrahq.slack.com/archives/C08SY9BLPCP/p1784123577636169)）に対応。

「10-1-2: Fortifyの認証機能を理解する」および「13-5-1: 認証機能の実装」内で紹介している `config/app.php` の `providers` 配列のコードが、Laravel 8以前の古い書き方になっていた。教材の対象である Laravel 10.x では、デフォルトで `ServiceProvider::defaultProviders()->merge([...])->toArray()` 形式で記述されており、旧形式のままだと以下のエラーが発生する。

- `Target class [files] does not exist.`
- `str_starts_with(): Argument #1 ($haystack) must be of type string, array given`

## 修正内容

- **`10-1-2_Fortifyの認証機能を理解する.md`**（サービスプロバイダの登録）
- **`13-5-1_認証機能の実装.md`**（ステップ3: サービスプロバイダの登録、および「よくある間違い」のNG例）

いずれも下記2箇所を修正:

- `'providers' => [` → `'providers' => ServiceProvider::defaultProviders()->merge([`
- `],` → `])->toArray(),`

## 確認観点

- [ ] 修正後のコードが Laravel 10.x のデフォルト `config/app.php` と整合していること
- [ ] 「よくある間違い」節のNG例も同形式に揃っていること

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9jSb9cKe1NoYme4hNLkXY)_