### PR TITLE
6-2-6: コード入力場所の注意書きを追加

### DIFF
--- a/curriculums/tutorial-6: 環境構築を楽にするdockerを学ぼう🐳/chapter-2: dockerの使い方/6-2-6_PHP実行環境の構築-ハンズオン.md
+++ b/curriculums/tutorial-6: 環境構築を楽にするdockerを学ぼう🐳/chapter-2: dockerの使い方/6-2-6_PHP実行環境の構築-ハンズオン.md
@@ -53,6 +53,8 @@ touch docker/nginx/default.conf
 
 VSCodeのエクスプローラーに`docker/nginx/default.conf`が表示されるので、クリックして開き、以下の内容を記述してください。
 
+> ⚠️ **注意**: 以下のコードは、VSCode下部のターミナル（コマンドを入力する黒い画面）ではなく、エクスプローラーからファイルをクリックして開いた**編集画面（画面上部のファイル欄）**に入力してください。以降のStepで登場する`src/index.php`や`docker-compose.yml`も同様に、編集画面に入力します。
+
 ```nginx
 # docker/nginx/default.conf
 server {


### PR DESCRIPTION
## 概要

Section 6-2-6（Docker Composeハンズオン）で、コードを「記述する」場所が初学者に伝わらず、VSCode下部のターミナルに入力してしまうケースが報告されたため、注意書きを追加します。

## 変更内容

Step 2（`docker/nginx/default.conf` を開く箇所）の直後に `> ⚠️ **注意**` ブロックを1つ追加。

- 「以下のコードは、VSCode下部のターミナル（コマンドを入力する黒い画面）ではなく、エクスプローラーからファイルをクリックして開いた**編集画面（画面上部のファイル欄）**に入力してください」と明記
- 「以降のStepで登場する `src/index.php` や `docker-compose.yml` も同様に、編集画面に入力します」と補足し、Step 3・Step 4の同一パターンも1回の注意書きでカバー

## 背景

Slackお問い合わせ（生徒様より、担当コーチ：八田 幸久）で、Step 3 の `src/index.php` の記述場所が分からずターミナルに入力してしまい、2週間ほど詰まってしまったという事例が報告されました。「クリックして開き、以下の内容を記述してください」という表現が、経験者には自明でも初学者には曖昧に映るため、明示的に編集画面である旨を追記します。

Closes #263

Slack: https://estrahq.slack.com/archives/C08SY9BLPCP/p1784195595194099


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfdop1v6odcwscvae2QQVa)_