### PR TITLE
7-1-6: git remote add origin エラー時の対処法を追記

### DIFF
--- a/curriculums/tutorial-7: PHPを使ってプログラミングをはじめよう🧩/chapter-1: PHPの基礎的な理解と使い方/7-1-6_PHPの基礎-ハンズオン演習.md
+++ b/curriculums/tutorial-7: PHPを使ってプログラミングをはじめよう🧩/chapter-1: PHPの基礎的な理解と使い方/7-1-6_PHPの基礎-ハンズオン演習.md
@@ -720,6 +720,23 @@ git branch -M main
 git push -u origin main
 ```
 
+> ⚠️ **`error: remote origin already exists.` と表示されたら**: 前回の試行などで `origin` がすでに登録されている状態です。以下のいずれかで対処できます。
+>
+> - すでに登録済みの `origin` の URL を、今回作成したリポジトリの URL に更新する場合：
+>
+>   ```bash
+>   git remote set-url origin <あなたのリポジトリのURL>
+>   ```
+>
+> - いったん `origin` の登録を削除してから、登録し直す場合：
+>
+>   ```bash
+>   git remote remove origin
+>   git remote add origin <あなたのリポジトリのURL>
+>   ```
+>
+> どちらで対処してもかまいません。処理後は `git remote -v` で `origin` に正しい URL が設定されているか確認しましょう。
+
 > ⚠️ **詰まったときは**: Tutorial 5-1-7「📤 GitHubに push しよう」や Tutorial 4-4-2〜4-4-3 を見直してみましょう。
 
 ### ✅ push 完了チェック


### PR DESCRIPTION
## 概要

Section 7-1-6「📤 GitHubに push しよう」の手順を実行した際、`git remote add origin <URL>` で `error: remote origin already exists.` エラーに遭遇したという受講生からのお問い合わせに対応するもの。

このエラー自体は「前回の試行などで `origin` がすでに登録されている」場合に発生する典型的なもので、多くの受講生が同様に躓く可能性が高いため、教材内で対処方法を案内する。

## 変更内容

- 「📤 GitHubに push しよう」セクションの `> ⚠️ **詰まったときは**` の直前に、`error: remote origin already exists.` エラーに対する対処法（`git remote set-url origin ...` で更新、または `git remote remove origin` してから再登録）を追記
- 対処後は `git remote -v` で確認するよう案内

## 補足

- 質問者は原因を「4-4-2 で origin を設定済みだから」と誤認していたが、4-4-2 は別ディレクトリ（`my-first-git`）の話であり原理上は影響しない
- 質問者提案の「`git remote add` → `git remote set-url` に一律置換」は、`origin` 未登録時に別のエラーを起こすため採用せず、注意書き追加という形で対処
- 同じ `git init` → `git remote add origin` パターンは 5-1-7、7-2-6 以降の PHP・Laravel ハンズオン多数、11-1-7・11-2-8 でも使用されているため、水平展開は別Issueで検討

Closes #265

Slack: https://estrahq.slack.com/archives/C08SY9BLPCP/p1784892509933489

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHGcwtcdDRXcZr5JSXAR5s)_