### PR TITLE
8-4-2: GROUP BY集計例の表に、複数ユーザー投稿を想定したイメージである旨を追記

### DIFF
--- a/curriculums/tutorial-8: データベースを使いこなそう📦/chapter-4: 高度なSQLクエリ/8-4-2_データの集計とグループ化.md
+++ b/curriculums/tutorial-8: データベースを使いこなそう📦/chapter-4: 高度なSQLクエリ/8-4-2_データの集計とグループ化.md
@@ -75,6 +75,11 @@ GROUP BY
 
 <img alt="8-4-2_1.png" src="https://s3.ap-northeast-1.amazonaws.com/coachtech-lms-bucket-dev/curriculums/images/8-4-2_1.png">
 
+> 💡 **表示される結果について**
+> 上の図と下の表は、複数のユーザーがそれぞれ複数の投稿をしている場合の**集計結果イメージ**です。8-3-2・8-3-3 で INSERT した`posts`テーブルには`user_id = 1`のレコードしか存在しないため、実際に手元で実行すると`user_id = 1, post_count = 3`の1行だけが返ります。ここでは`GROUP BY`の挙動を分かりやすく示すため、複数ユーザーが投稿しているケースを例として掲載しています。
+
+**集計結果イメージ（複数ユーザーが投稿している場合）：**
+
 | user_id | post_count |
 |:---|:---|
 | 1 | 5 |


### PR DESCRIPTION
## 概要

Slackお問い合わせ（[permalink](https://estrahq.slack.com/archives/C08SY9BLPCP/p1785884629845419)）で指摘のあった、8-4-2「GROUP BY句：グループごとの集計」の集計結果表と手元のDB状態の不一致を修正します。

Closes #268

## 背景

8-3-2・8-3-3 の INSERT 文で登録される `posts` テーブルのデータは `user_id = 1` の3件のみです。
しかし 8-4-2 では `GROUP BY user_id` の実行結果として `user_id = 1, 2, 4` の3行が並ぶ表を掲載しており、学習者が手元で実行した結果（`user_id = 1, post_count = 3` の1行）と食い違うため、混乱の原因になっていました。

## 変更内容

- `curriculums/tutorial-8: データベースを使いこなそう📦/chapter-4: 高度なSQLクエリ/8-4-2_データの集計とグループ化.md`
  - `GROUP BY` の集計結果表の直前に、この表が「複数ユーザーが投稿している場合の集計結果イメージ」であることを説明する `💡 TIP` ブロックを追加
  - 手元のDBでは `user_id = 1, post_count = 3` の1行のみが返る旨を明記
  - 表の見出しを「集計結果イメージ（複数ユーザーが投稿している場合）」に変更

## 修正方針の選択理由

質問者提案の3案のうち、以下の理由で①（例示であることを明記）を採用しました。

- ② 表を削除する案：`GROUP BY` の挙動を視覚的に理解する上で有用な例であり、削除は学習効果を下げる。
- ③ 追加のINSERTを促す案：既存のチャプター構成に影響が及ぶうえ、以降のセクションで想定する `posts` の状態が変わってしまう可能性がある。
- ① 例示であることを明記する案：本文中の1ブロック追加で完結し、副作用が最小。

## Slack対応スレッド

- 元スレッド（改善要望）: https://estrahq.slack.com/archives/C08SY9BLPCP/p1785884629845419
- 追記スレッド（対象図の特定）: https://estrahq.slack.com/archives/C08SY9BLPCP/p1785887178555359

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVXiPNbrURsaz8GUnJKcP9)_